### PR TITLE
feat: add launch button animation

### DIFF
--- a/apps/desktop/src/components/toolbar.tsx
+++ b/apps/desktop/src/components/toolbar.tsx
@@ -1,6 +1,7 @@
 import { Check, GameController, Play, Stop, X } from '@phosphor-icons/react';
 import { invoke } from '@tauri-apps/api/core';
 import { useQuery } from 'react-query';
+import { useState } from 'react';
 import { useLaunch } from '@/hooks/use-launch';
 import { isGameRunning } from '@/lib/api';
 import { usePersistedStore } from '@/lib/store';
@@ -12,6 +13,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 export const Toolbar = () => {
   const { gamePath } = usePersistedStore();
   const { launch } = useLaunch();
+  const [vanillaAnimating, setVanillaAnimating] = useState(false);
+  const [moddedAnimating, setModdedAnimating] = useState(false);
 
   const { data: isRunning, refetch } = useQuery({
     queryKey: ['is-game-running'],
@@ -44,23 +47,49 @@ export const Toolbar = () => {
       {!isRunning && (
         <Button
           disabled={!gamePath}
-          onClick={() => launch(true)}
+          onClick={() => {
+            setVanillaAnimating(true);
+            launch(true);
+            setTimeout(() => setVanillaAnimating(false), 500);
+          }}
           size="lg"
           variant="ghost"
+          className="relative overflow-hidden"
         >
+          <div
+            className={cn(
+              'absolute inset-0 bg-white/30',
+              vanillaAnimating ? 'w-full transition-all duration-500 ease-in-out' : 'w-0'
+            )}
+          />
           <Play />
-          <span className="font-medium text-md">Launch Vanilla</span>
+          <span className="font-medium text-md relative z-10">Launch Vanilla</span>
         </Button>
       )}
       <Button
         disabled={!gamePath}
-        onClick={() =>
-          isRunning ? invoke('stop_game').then(() => refetch()) : launch()
-        }
+        onClick={() => {
+          if (isRunning) {
+            invoke('stop_game').then(() => refetch());
+          } else {
+            setModdedAnimating(true);
+            launch();
+            setTimeout(() => setModdedAnimating(false), 500);
+          }
+        }}
         size="lg"
+        className="relative overflow-hidden"
       >
-        {isRunning ? <Stop /> : <GameController />}
-        <span className="font-medium text-md">
+        <div
+          className={cn(
+            'absolute inset-0 bg-amber-200',
+            moddedAnimating ? 'w-full transition-all duration-500 ease-in-out' : 'w-0'
+          )}
+        />
+        <div className="relative z-10">
+          {isRunning ? <Stop /> : <GameController />}
+        </div>
+        <span className="font-medium text-md relative z-10">
           {isRunning ? 'Stop Game' : 'Launch Modded'}
         </span>
       </Button>


### PR DESCRIPTION
## Summary
Added click animations to the toolbar launch buttons (Vanilla & Modded).  
When clicked, each button now shows a short "filling" effect.

## Changes
- Vanilla button: white fill animation
- Modded button: amber fill animation
- Animation length: 500ms, then resets
- Adjusted z-index so the icons always stay visible

## Implementation
- Tracked animation state with `useState`
- Added a timeout to clear state after 500ms

## Files Updated
- `apps/desktop/src/components/toolbar.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch buttons now show a brief progress overlay when starting Vanilla or Modded, providing immediate visual feedback.
  * Modded button dynamically switches between “Launch Modded” and “Stop Game” based on game status, enabling quick stop actions from the toolbar.

* **Style**
  * Added subtle animated overlays to both launch buttons for a more responsive feel.
  * Ensured button labels and icons remain clearly visible during animations for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->