### PR TITLE
fix: add scrollbar to file-selector-dialog

### DIFF
--- a/apps/desktop/src/components/file-selector-dialog.tsx
+++ b/apps/desktop/src/components/file-selector-dialog.tsx
@@ -171,7 +171,7 @@ export const FileSelectorDialog = ({
             </span>
           </div>
 
-          <ScrollArea className="max-h-[50vh] pr-4">
+          <ScrollArea className="max-h-[50vh] overflow-y-auto pr-4">
             <div className="space-y-4">
               {hasMultipleArchives ? (
                 // Group view - show files grouped by archive


### PR DESCRIPTION
fixes #65

previously this area didnt have a scrollbar and with mods that have lots of vpks to choose from there was no way to see more other than just making the window bigger

[N3xiypG0x.webm](https://github.com/user-attachments/assets/02da9e82-8c15-4773-9429-ced53b3b62e7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The File Selector dialog now scrolls vertically when content exceeds the visible area, preventing items from being hidden and making long lists easier to browse.
  - Improves usability and accessibility for large folders, with reliable keyboard and mouse/trackpad navigation across the full list.
  - Ensures consistent behavior across different window sizes and displays.
  - No changes to existing workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->